### PR TITLE
Busca todos os arquivos de um Pull Request

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4223,14 +4223,12 @@ isStream.transform = function (stream) {
 const path = __webpack_require__(622);
 const fs = __webpack_require__(747);
 
-const listFiles = async (options) => {
+const listFilesFromPR = async (options) => {
   const {
     client,
     owner,
     repo,
     prNumber,
-    filterPath,
-    log
   } = options;
 
   let firstOrHasNext = true;
@@ -4254,6 +4252,25 @@ const listFiles = async (options) => {
       firstOrHasNext = false;
     }
   }
+  return files;
+};
+
+const listFiles = async (options) => {
+  const {
+    client,
+    owner,
+    repo,
+    prNumber,
+    filterPath,
+    log
+  } = options;
+
+  const files = await listFilesFromPR({
+    client,
+    owner,
+    repo,
+    prNumber,
+  });
 
   return files
     .filter(({ filename, status }) => filename.includes(filterPath) && status !== 'removed')
@@ -4310,27 +4327,12 @@ const listRemovedFiles = async (options) => {
     log
   } = options;
 
-  let firstOrHasNext = true;
-  let files = [];
-  let per_page = 100;
-  let page = 1;
-
-  while (firstOrHasNext) {
-    const { data } = await client.pulls.listFiles({
-      owner,
-      repo,
-      pull_number: prNumber,
-      per_page,
-      page,
-    });
-
-    if (data.length > 0) {
-      files.push(...data);
-      page += 1;
-    } else {
-      firstOrHasNext = false;
-    }
-  }
+  const files = await listFilesFromPR({
+    client,
+    owner,
+    repo,
+    prNumber,
+  });
 
   return files
     .filter(({ status }) => status === 'removed')

--- a/dist/index.js
+++ b/dist/index.js
@@ -4233,13 +4233,28 @@ const listFiles = async (options) => {
     log
   } = options;
 
-  const { data: files } = await client.pulls.listFiles({
-    owner,
-    repo,
-    pull_number: prNumber,
-    per_page: 100,
-    page: 1,
-  });
+  let firstOrHasNext = true;
+  let files = [];
+  let per_page = 100;
+  let page = 1;
+
+  while (firstOrHasNext) {
+    const { data } = await client.pulls.listFiles({
+      owner,
+      repo,
+      pull_number: prNumber,
+      per_page,
+      page,
+    });
+
+    if (data.length > 0) {
+      files.push(...data);
+      page += 1;
+    } else {
+      firstOrHasNext = false;
+    }
+  }
+
   return files
     .filter(({ filename, status }) => filename.includes(filterPath) && status !== 'removed')
     .map(({ filename }) => filename);
@@ -4295,13 +4310,28 @@ const listRemovedFiles = async (options) => {
     log
   } = options;
 
-  const { data: files } = await client.pulls.listFiles({
-    owner,
-    repo,
-    pull_number: prNumber,
-    per_page: 100,
-    page: 1,
-  });
+  let firstOrHasNext = true;
+  let files = [];
+  let per_page = 100;
+  let page = 1;
+
+  while (firstOrHasNext) {
+    const { data } = await client.pulls.listFiles({
+      owner,
+      repo,
+      pull_number: prNumber,
+      per_page,
+      page,
+    });
+
+    if (data.length > 0) {
+      files.push(...data);
+      page += 1;
+    } else {
+      firstOrHasNext = false;
+    }
+  }
+
   return files
     .filter(({ status }) => status === 'removed')
     .map(({ filename }) => filename);

--- a/main.js
+++ b/main.js
@@ -1,14 +1,12 @@
 const path = require('path');
 const fs = require('fs');
 
-const listFiles = async (options) => {
+const listFilesFromPR = async (options) => {
   const {
     client,
     owner,
     repo,
     prNumber,
-    filterPath,
-    log
   } = options;
 
   let firstOrHasNext = true;
@@ -32,6 +30,25 @@ const listFiles = async (options) => {
       firstOrHasNext = false;
     }
   }
+  return files;
+};
+
+const listFiles = async (options) => {
+  const {
+    client,
+    owner,
+    repo,
+    prNumber,
+    filterPath,
+    log
+  } = options;
+
+  const files = await listFilesFromPR({
+    client,
+    owner,
+    repo,
+    prNumber,
+  });
 
   return files
     .filter(({ filename, status }) => filename.includes(filterPath) && status !== 'removed')
@@ -88,27 +105,12 @@ const listRemovedFiles = async (options) => {
     log
   } = options;
 
-  let firstOrHasNext = true;
-  let files = [];
-  let per_page = 100;
-  let page = 1;
-
-  while (firstOrHasNext) {
-    const { data } = await client.pulls.listFiles({
-      owner,
-      repo,
-      pull_number: prNumber,
-      per_page,
-      page,
-    });
-
-    if (data.length > 0) {
-      files.push(...data);
-      page += 1;
-    } else {
-      firstOrHasNext = false;
-    }
-  }
+  const files = await listFilesFromPR({
+    client,
+    owner,
+    repo,
+    prNumber,
+  });
 
   return files
     .filter(({ status }) => status === 'removed')

--- a/main.js
+++ b/main.js
@@ -11,13 +11,28 @@ const listFiles = async (options) => {
     log
   } = options;
 
-  const { data: files } = await client.pulls.listFiles({
-    owner,
-    repo,
-    pull_number: prNumber,
-    per_page: 100,
-    page: 1,
-  });
+  let firstOrHasNext = true;
+  let files = [];
+  let per_page = 100;
+  let page = 1;
+
+  while (firstOrHasNext) {
+    const { data } = await client.pulls.listFiles({
+      owner,
+      repo,
+      pull_number: prNumber,
+      per_page,
+      page,
+    });
+
+    if (data.length > 0) {
+      files.push(...data);
+      page += 1;
+    } else {
+      firstOrHasNext = false;
+    }
+  }
+
   return files
     .filter(({ filename, status }) => filename.includes(filterPath) && status !== 'removed')
     .map(({ filename }) => filename);
@@ -73,13 +88,28 @@ const listRemovedFiles = async (options) => {
     log
   } = options;
 
-  const { data: files } = await client.pulls.listFiles({
-    owner,
-    repo,
-    pull_number: prNumber,
-    per_page: 100,
-    page: 1,
-  });
+  let firstOrHasNext = true;
+  let files = [];
+  let per_page = 100;
+  let page = 1;
+
+  while (firstOrHasNext) {
+    const { data } = await client.pulls.listFiles({
+      owner,
+      repo,
+      pull_number: prNumber,
+      per_page,
+      page,
+    });
+
+    if (data.length > 0) {
+      files.push(...data);
+      page += 1;
+    } else {
+      firstOrHasNext = false;
+    }
+  }
+
   return files
     .filter(({ status }) => status === 'removed')
     .map(({ filename }) => filename);

--- a/main.test.js
+++ b/main.test.js
@@ -66,18 +66,23 @@ describe('Main', () => {
   });
 
   it('list all modified files from Pull Request', async () => {
-    client.pulls.listFiles.mockResolvedValue({
-      data: [{
-        filename: 'README.md',
-        status: 'modified',
-      }, {
-        filename: 'content/meu-arquivo.md',
-        status: 'added',
-      }, {
-        filename: 'wait.js',
-        status: 'removed',
-      }]
-    });
+    client.pulls.listFiles
+      .mockResolvedValueOnce({
+        data: [{
+          filename: 'README.md',
+          status: 'modified',
+        }, {
+          filename: 'content/meu-arquivo.md',
+          status: 'added',
+        }, {
+          filename: 'wait.js',
+          status: 'removed',
+        }]
+      })
+      .mockResolvedValueOnce({
+        data: []
+      }
+    );
     const expected = [
       'README.md',
       'content/meu-arquivo.md',
@@ -88,18 +93,23 @@ describe('Main', () => {
   });
 
   it('list filtered files from Pull Request', async () => {
-    client.pulls.listFiles.mockResolvedValue({
-      data: [{
-        filename: 'README.md',
-        status: 'modified',
-      }, {
-        filename: 'content/meu-arquivo.md',
-        status: 'added',
-      }, {
-        filename: 'wait.js',
-        status: 'removed',
-      }]
-    });
+    client.pulls.listFiles
+      .mockResolvedValueOnce({
+        data: [{
+          filename: 'README.md',
+          status: 'modified',
+        }, {
+          filename: 'content/meu-arquivo.md',
+          status: 'added',
+        }, {
+          filename: 'wait.js',
+          status: 'removed',
+        }]
+      })
+      .mockResolvedValueOnce({
+        data: []
+      }
+    );
     const expected = [
       'content/meu-arquivo.md',
     ];
@@ -170,15 +180,20 @@ describe('Main', () => {
   });
 
   it('download files from pull request', async () => {
-    client.pulls.listFiles.mockResolvedValue({
-      data: [{
-        filename: 'README.md',
-        status: 'modified',
-      }, {
-        filename: 'content/meu-arquivo.md',
-        status: 'added',
-      }]
-    });
+    client.pulls.listFiles
+      .mockResolvedValueOnce({
+        data: [{
+          filename: 'README.md',
+          status: 'modified',
+        }, {
+          filename: 'content/meu-arquivo.md',
+          status: 'added',
+        }]
+      })
+      .mockResolvedValueOnce({
+        data: []
+      }
+    );
     client.repos.getContents
       .mockResolvedValueOnce({
         data: {
@@ -209,15 +224,20 @@ describe('Main', () => {
   });
 
   it('download filtered files from pull request', async () => {
-    client.pulls.listFiles.mockResolvedValue({
-      data: [{
-        filename: 'README.md',
-        status: 'modified',
-      }, {
-        filename: 'content/meu-arquivo.md',
-        status: 'added',
-      }]
-    });
+    client.pulls.listFiles
+      .mockResolvedValueOnce({
+        data: [{
+          filename: 'README.md',
+          status: 'modified',
+        }, {
+          filename: 'content/meu-arquivo.md',
+          status: 'added',
+        }]
+      })
+      .mockResolvedValueOnce({
+        data: []
+      }
+    );
     client.repos.getContents
       .mockResolvedValueOnce({
         data: {
@@ -237,15 +257,20 @@ describe('Main', () => {
   });
 
   it('download files from pull request in specific directory', async () => {
-    client.pulls.listFiles.mockResolvedValue({
-      data: [{
-        filename: 'README.md',
-        status: 'modified',
-      }, {
-        filename: 'content/meu-arquivo.md',
-        status: 'added',
-      }]
-    });
+    client.pulls.listFiles
+      .mockResolvedValueOnce({
+        data: [{
+          filename: 'README.md',
+          status: 'modified',
+        }, {
+          filename: 'content/meu-arquivo.md',
+          status: 'added',
+        }]
+      })
+      .mockResolvedValueOnce({
+        data: []
+      }
+    );
     client.repos.getContents
       .mockResolvedValueOnce({
         data: {
@@ -276,18 +301,23 @@ describe('Main', () => {
   });
 
   it('list all removed files from Pull Request', async () => {
-    client.pulls.listFiles.mockResolvedValue({
-      data: [{
-        filename: 'README.md',
-        status: 'removed',
-      }, {
-        filename: 'content/meu-arquivo.md',
-        status: 'added',
-      }, {
-        filename: 'wait.js',
-        status: 'removed',
-      }]
-    });
+    client.pulls.listFiles
+      .mockResolvedValueOnce({
+        data: [{
+          filename: 'README.md',
+          status: 'removed',
+        }, {
+          filename: 'content/meu-arquivo.md',
+          status: 'added',
+        }, {
+          filename: 'wait.js',
+          status: 'removed',
+        }]
+      })
+      .mockResolvedValueOnce({
+        data: []
+      }
+    );
     const expected = [
       'README.md',
       'wait.js',
@@ -298,18 +328,23 @@ describe('Main', () => {
   });
 
   it('empty list when no file was removed', async () => {
-    client.pulls.listFiles.mockResolvedValue({
-      data: [{
-        filename: 'README.md',
-        status: 'modified',
-      }, {
-        filename: 'content/meu-arquivo.md',
-        status: 'added',
-      }, {
-        filename: 'wait.js',
-        status: 'modified',
-      }]
-    });
+    client.pulls.listFiles
+      .mockResolvedValue({
+        data: [{
+          filename: 'README.md',
+          status: 'modified',
+        }, {
+          filename: 'content/meu-arquivo.md',
+          status: 'added',
+        }, {
+          filename: 'wait.js',
+          status: 'modified',
+        }]
+      })
+      .mockResolvedValueOnce({
+        data: []
+      }
+    );
     const expected = [];
     const filenames = await runListRemovedFiles();
     expect(client.pulls.listFiles).toHaveBeenCalled();

--- a/main.test.js
+++ b/main.test.js
@@ -117,6 +117,69 @@ describe('Main', () => {
     expect(filenames).toEqual(expected);
   });
 
+  it('list files from Pull Request when there is just one page', async () => {
+    client.pulls.listFiles
+      .mockResolvedValueOnce({
+        data: [{
+          filename: 'README.md',
+          status: 'modified',
+        }, {
+          filename: 'content/meu-arquivo.md',
+          status: 'added',
+        }, {
+          filename: 'wait.js',
+          status: 'removed',
+        }, {
+          filename: 'content/backend/intro.md',
+          status: 'modified',
+        }]
+      })
+      .mockResolvedValueOnce({
+        data: []
+      }
+    );
+    const expected = [
+      'README.md',
+      'content/meu-arquivo.md',
+      'content/backend/intro.md',
+    ];
+    const filenames = await runListFiles('');
+    expect(filenames).toEqual(expected);
+  });
+
+  it('list files from Pull Request when there are many pages', async () => {
+    client.pulls.listFiles
+      .mockResolvedValueOnce({
+        data: [{
+          filename: 'README.md',
+          status: 'modified',
+        }, {
+          filename: 'content/meu-arquivo.md',
+          status: 'added',
+        }]
+      })
+      .mockResolvedValueOnce({
+        data: [{
+          filename: 'wait.js',
+          status: 'removed',
+        }, {
+          filename: 'content/backend/intro.md',
+          status: 'modified',
+        }]
+      })
+      .mockResolvedValueOnce({
+        data: []
+      }
+    );
+    const expected = [
+      'README.md',
+      'content/meu-arquivo.md',
+      'content/backend/intro.md',
+    ];
+    const filenames = await runListFiles('');
+    expect(filenames).toEqual(expected);
+  });
+
   it('download file', async () => {
     client.repos.getContents.mockResolvedValue({
       data: {


### PR DESCRIPTION
o método `client.pulls.listFiles` tem um limite de 100 registros por chamada. Esse Pull Request resolve o problema de buscar todas as páginas de um Pull Request, mesmo que a quantidade seja maior que o limite de apenas uma requisição